### PR TITLE
some correction in getGenres

### DIFF
--- a/src/js/services/Api_services.js
+++ b/src/js/services/Api_services.js
@@ -93,7 +93,7 @@ export default class ApiServices {
     const url = `${BASE_URL}/genre/movie/list?api_key=${API_KEY}`;
     try {
       const { data } = await axios.get(url);
-      localStore.save('genres',data)
+      localStore.save('genres',data.genres)
       return data;
     } catch (error) {
       console.error('getGenres says:', error);

--- a/src/js/services/connect_genres.js
+++ b/src/js/services/connect_genres.js
@@ -38,3 +38,5 @@ export default function getGenres(genre_ids) {
 
   return arr.join(', ');
 }
+
+


### PR DESCRIPTION
  async getGenres(){
    const url = `${BASE_URL}/genre/movie/list?api_key=${API_KEY}`;
    try {
      const { data } = await axios.get(url);
      localStore.save('genres',data.GENRES)
      return data;
    } catch (error) {
      console.error('getGenres says:', error);
    }
  }
===============
